### PR TITLE
fix: add missing eslint-plugin-react-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "conventional-changelog-conventionalcommits": "4.6.3",
     "eslint": "8.15.0",
     "eslint-plugin-react": "7.29.4",
+    "eslint-plugin-react-hooks": "^4.5.0",
     "node-fetch": "3.2.4",
     "semantic-release": "19.0.2",
     "typescript": "4.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   conventional-changelog-conventionalcommits: 4.6.3
   eslint: 8.15.0
   eslint-plugin-react: 7.29.4
+  eslint-plugin-react-hooks: ^4.5.0
   node-fetch: 3.2.4
   react: ^18.0.0
   react-dom: ^18.0.0
@@ -46,6 +47,7 @@ devDependencies:
   conventional-changelog-conventionalcommits: 4.6.3
   eslint: 8.15.0
   eslint-plugin-react: 7.29.4_eslint@8.15.0
+  eslint-plugin-react-hooks: 4.5.0_eslint@8.15.0
   node-fetch: 3.2.4
   semantic-release: 19.0.2
   typescript: 4.6.4
@@ -1752,6 +1754,15 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-plugin-react-hooks/4.5.0_eslint@8.15.0:
+    resolution: {integrity: sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.15.0
     dev: true
 
   /eslint-plugin-react/7.29.4_eslint@8.15.0:


### PR DESCRIPTION
plugin `react-hooks` exists in eslintrc.json
but not listed in `package.json`